### PR TITLE
Remove useless warnings from MulleObjC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ endif()
 
 add_library( MulleObjCStandalone SHARED
 src/MulleObjCStandalone.m
+${HEADERS}
 ${DEF_FILE}
 )
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ on top of it. MulleObjC fundamentally depends on standard C libraries only
 Fork      |  Build Status | Release Version
 ----------|---------------|-----------------------------------
 [Mulle kybernetiK](//github.com/mulle-nat/MulleObjC) | [![Build Status](https://travis-ci.org/mulle-nat/MulleObjC.svg?branch=release)](https://travis-ci.org/mulle-nat/MulleObjC) | ![Mulle kybernetiK tag](https://img.shields.io/github/tag/mulle-nat/MulleObjC.svg) [![Build Status](https://travis-ci.org/mulle-nat/MulleObjC.svg?branch=release)](https://travis-ci.org/mulle-nat/MulleObjC)
-[Community](https://github.com/MulleObjC/MulleObjC/tree/release) | [![Build Status](https://travis-ci.org/MulleObjC/MulleObjC.svg)](https://travis-ci.org/MulleObjC/MulleObjC) | ![Community tag](https://img.shields.io/github/tag/MulleObjC/MulleObjC.svg) [![Build Status](https://travis-ci.org/MulleObjC/MulleObjC.svg?branch=release)](https://travis-ci.org/MulleObjC/MulleObjC)
+[Community](https://github.com/mulle-objc/MulleObjC/tree/release) | [![Build Status](https://travis-ci.org/mulle-objc/MulleObjC.svg)](https://travis-ci.org/mulle-objc/MulleObjC) | ![Community tag](https://img.shields.io/github/tag/mulle-objc/MulleObjC.svg) [![Build Status](https://travis-ci.org/mulle-objc/MulleObjC.svg?branch=release)](https://travis-ci.org/mulle-objc/MulleObjC)
 
 
 ### Objects

--- a/README.md
+++ b/README.md
@@ -59,28 +59,18 @@ When using static libraries, `-ObjC` doesn't work, because the compiler doesn't
 produce ObjC segments. Use `-all_load`.
 
 
-## Dependencies
-
-
-
 ## Install
 
-On OS X and Linux you can use
-[homebrew](//brew.sh), respectively
-[linuxbrew](//linuxbrew.sh)
-to install the library:
+On OS X you can use [homebrew](//brew.sh) to install the library:
 
 ```
-brew tap mulle-kybernetik/software
-brew tap mulle-objc/software
-brew install MulleObjC
+brew install mulle-objc/software/mulleobjc
 ```
 
 to install the compiler:
 
 ```
-brew tap codeon-gmbh/software
-brew install mulle-clang
+brew install codeon-gmbh/software/mulle-clang
 ```
 
 On other platforms you can use **mulle-install** from

--- a/src/NSAutoreleasePool.h
+++ b/src/NSAutoreleasePool.h
@@ -17,6 +17,10 @@
 #import "ns_threadconfiguration.h"
 
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-root-class"
+
+
 //
 // if you feel the need to subclass this, change the
 // NSAutoreleasePoolConfiguration, to use your functions
@@ -59,6 +63,9 @@
 + (NSUInteger) _countObject:(id) p;
 
 @end
+
+
+#pragma clang diagnostic pop
 
 
 //

--- a/src/NSCoder.m
+++ b/src/NSCoder.m
@@ -49,6 +49,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 @end
 
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-root-class"
+
+
 #pragma mark -
 #pragma mark MulleObjCUnkeyedArchiver Protocol with default implementations
 
@@ -74,6 +78,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 - (void) encodePropertyList:(id) aPropertyList;
 
 @end
+
+
+#pragma clang diagnostic pop
 
 
 @implementation MulleObjCUnkeyedArchiver
@@ -178,6 +185,10 @@ static void   codecValuesOfObjCTypes( NSCoder< NSObject> *self,
 @end
 
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-root-class"
+
+
 #pragma mark -
 #pragma mark MulleObjCUnkeyedUnarchiver Protocol with default implementations
 
@@ -200,6 +211,9 @@ static void   codecValuesOfObjCTypes( NSCoder< NSObject> *self,
 - (id) decodePropertyList;
 
 @end
+
+
+#pragma clang diagnostic pop
 
 
 @implementation MulleObjCUnkeyedUnarchiver

--- a/src/NSDebug.m
+++ b/src/NSDebug.m
@@ -74,6 +74,9 @@ char   *_NSPrintForDebugger( id a)
 }
 
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-root-class"
+
 
 @interface _MulleObjCZombie
 {
@@ -118,6 +121,9 @@ static char   zombie_format[] = "A deallocated object %p of %sclass \"%s\" was s
 }
 
 @end
+
+
+#pragma clang diagnostic pop
 
 
 #define MULLE_ZOMBIE_HASH              0x057fc0af  // _MulleObjCZombie

--- a/src/NSObject.h
+++ b/src/NSObject.h
@@ -20,6 +20,8 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnullability-completeness"
 #pragma clang diagnostic ignored "-Wcast-of-sel-type"
+#pragma clang diagnostic ignored "-Wobjc-root-class"
+
 
 //
 // +load: mulle-objc-runtime guarantees, that the class and therefore the

--- a/src/NSObject.m
+++ b/src/NSObject.m
@@ -43,8 +43,13 @@
 
 #define _MulleObjCInstantiatePlaceholderHash  0x56154b76  // _MulleObjCInstantiatePlaceholder
 
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-root-class"
+
+
 // intentonally a root object (!)
-@interface _MulleObjCInstantiatePlaceholder 
+@interface _MulleObjCInstantiatePlaceholder
 {
 @public
    Class   _cls;
@@ -104,6 +109,10 @@
 }
 
 @end
+
+
+#pragma clang diagnostic pop
+
 
 #pragma mark -
 #pragma mark ### NSObject ###

--- a/src/protocols/MulleObjCClassCluster.m
+++ b/src/protocols/MulleObjCClassCluster.m
@@ -14,6 +14,10 @@
 // std-c and dependencies
 
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-root-class"
+
+
 @interface MulleObjCClassCluster < MulleObjCClassCluster>
 @end
 
@@ -81,3 +85,8 @@ static id   MulleObjCNewClassClusterPlaceholder( struct _mulle_objc_class  *self
 }
 
 @end
+
+
+#pragma clang diagnostic pop
+
+

--- a/src/protocols/MulleObjCException.m
+++ b/src/protocols/MulleObjCException.m
@@ -9,6 +9,10 @@
 #import "MulleObjCException.h"
 
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-root-class"
+
+
 @interface MulleObjCException < MulleObjCException>
 
 // don't use __attribute(( noreturn)), the compiler will produce
@@ -30,3 +34,6 @@
 }
 
 @end
+
+
+#pragma clang diagnostic pop

--- a/src/protocols/MulleObjCSingleton.m
+++ b/src/protocols/MulleObjCSingleton.m
@@ -13,6 +13,10 @@
 #include "ns_type.h"
 
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-root-class"
+
+
 @interface MulleObjCSingleton < MulleObjCSingleton>
 @end
 
@@ -68,3 +72,6 @@ id  MulleObjCSingletonCreate( Class self)
 
 
 @end
+
+
+#pragma clang diagnostic pop

--- a/src/protocols/NSCopying.m
+++ b/src/protocols/NSCopying.m
@@ -18,6 +18,11 @@
 
 @end
 
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-root-class"
+
+
 // what is this ?
 // by default NSObject does not implement copyWithZone:
 // I want to keep it this way.
@@ -39,6 +44,9 @@
 }
 
 @end
+
+
+#pragma clang diagnostic pop
 
 
 //


### PR DESCRIPTION
- [suppressed "-Wobjc-root-class" warnings](https://github.com/orgs/mulle-objc/projects/9)
- rebased master with release branch.

If I need to add `copyrights` in the scope of this PR just let me know.

